### PR TITLE
Match.toMap() to get match in java Map.

### DIFF
--- a/src/main/java/com/nflabs/Grok/Match.java
+++ b/src/main/java/com/nflabs/Grok/Match.java
@@ -122,6 +122,14 @@ public class Match {
 	
 	/**
 	 * 
+	 * @return java map object from the matched element in the text
+	 */
+	public Map<String, String> toMap(){
+		return _capture;
+	}
+	
+	/**
+	 * 
 	 */
 	private void cleanMap(){
 		garbage.remove(_capture);

--- a/src/test/java/com/nflabs/Grok/GrokTest.java
+++ b/src/test/java/com/nflabs/Grok/GrokTest.java
@@ -1,0 +1,39 @@
+package com.nflabs.Grok;
+
+import java.util.Map;
+
+import junit.framework.TestCase;
+
+public class GrokTest extends TestCase {
+
+	protected void setUp() throws Exception {
+		super.setUp();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+	}
+
+	/**
+	 * Do some basic test
+	 * 
+	 * @throws Throwable
+	 */
+	public void testGrok() throws Throwable{
+    	Grok g = new Grok();
+
+		g.addPatternFromFile("patterns/base");
+			
+		g.compile("%{URI}");
+			
+		Match gm = g.match("http://www.google.com/search=lol");
+		gm.captures();
+		
+		Map<String, String> map = gm.toMap();
+		assertEquals("www.google.com", map.get("HOSTNAME"));
+		assertEquals("www.google.com", map.get("host"));
+		assertEquals("http", map.get("proto"));
+		assertEquals(null, map.get("port"));
+		assertEquals("/search=lol", map.get("params"));
+	}
+}


### PR DESCRIPTION
currently only Match.toJson() is available to get match.

Match.toMap() returns match in Map. which is good for some case (unit testing, java application embedding grok-java, etc)

also i have added the most basic unit test class.
