### PR TITLE
Thread safety

### DIFF
--- a/src/main/java/oi/thekraken/grok/api/Match.java
+++ b/src/main/java/oi/thekraken/grok/api/Match.java
@@ -41,6 +41,9 @@ public class Match {
   private int start;
   private int end;
   
+  /**
+   * For thread safety
+   */
   private static ThreadLocal<Match> matchHolder = new ThreadLocal<Match>() {
 	  @Override
 	  protected Match initialValue() {

--- a/src/test/java/io/thekraken/grok/api/ConcurrencyTest.java
+++ b/src/test/java/io/thekraken/grok/api/ConcurrencyTest.java
@@ -19,9 +19,16 @@ import org.junit.Test;
 
 public class ConcurrencyTest {
 
+	/**
+	 * We will test this by setting up two threads, asserting on the hash values
+	 * the instances generate for each thread
+	 * @throws InterruptedException
+	 * @throws ExecutionException
+	 */
 	@Test
 	public void test_001_concurrent_match() throws InterruptedException, ExecutionException {
-
+		
+		// Setup callable method that reports the hashcode for the thread
 		int threadCount = 2;
 		Callable<Integer> task = new Callable<Integer>() {
 			@Override
@@ -29,18 +36,23 @@ public class ConcurrencyTest {
 				return Match.getInstance().hashCode();
 			}
 		};
+		
+		// Create n tasks to execute
 		List<Callable<Integer>> tasks = Collections.nCopies(threadCount, task);
 	    
+		// Execute the task for both tasks
 		ExecutorService es = Executors.newFixedThreadPool(threadCount);
 		List<Future<Integer>> futures = es.invokeAll(tasks);
 		int hash1 = futures.get(0).get();
 		int hash2 = futures.get(1).get();
 		
+		// The two hashcodes must NOT be equal
 		Assert.assertThat(hash1, not(equalTo(hash2)));
 	}
 	
 	@Test
 	public void test_002_match_within_instance() {
+		// Verify that the instances are equal for the same thread
 		Match m1 = Match.getInstance();
 		Match m2 = Match.getInstance();
 		assertEquals(m1, m2);


### PR DESCRIPTION
The match function is not thread safe. Match.getInstance currently returns a global singleton. I have ensured that the MatchHolder is now ThreadLocal. Tests provided.
