### PR TITLE
Replace explicit dependency on slf4j-log4j12 with slf4j-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile "com.github.tony19:named-regexp:0.2.3"
     compile "org.apache.commons:commons-lang3:3.1"
     compile "com.google.code.gson:gson:2.2.2"
-    compile "org.slf4j:slf4j-log4j12:1.7.5"
+    compile "org.slf4j:slf4j-api:1.7.5"
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 


### PR DESCRIPTION
This commit fixes warnings when including grok in other frameworks
that use slf4j, such as Grails. For a description on the issue see
http://www.slf4j.org/codes.html#multiple_bindings.
