### PR TITLE
adding data-type conversion to grok patterns.

### DIFF
--- a/patterns/patterns
+++ b/patterns/patterns
@@ -101,6 +101,8 @@ MESSAGESLOG %{SYSLOGBASE} %{DATA}
 
 COMMONAPACHELOG %{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
 COMBINEDAPACHELOG %{COMMONAPACHELOG} %{QS:referrer} %{QS:agent}
+COMMONAPACHELOG_DATATYPED %{IPORHOST:clientip} %{USER:ident;boolean} %{USER:auth} \[%{HTTPDATE:timestamp;date;dd/MMM/yyyy:HH:mm:ss Z}\] "(?:%{WORD:verb;string} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion;float})?|%{DATA:rawrequest})" %{NUMBER:response;int} (?:%{NUMBER:bytes;long}|-)
+
 
 # Log Levels
 LOGLEVEL ([A|a]lert|ALERT|[T|t]race|TRACE|[D|d]ebug|DEBUG|[N|n]otice|NOTICE|[I|i]nfo|INFO|[W|w]arn?(?:ing)?|WARN?(?:ING)?|[E|e]rr?(?:or)?|ERR?(?:OR)?|[C|c]rit?(?:ical)?|CRIT?(?:ICAL)?|[F|f]atal|FATAL|[S|s]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)

--- a/src/main/java/oi/thekraken/grok/api/Converter.java
+++ b/src/main/java/oi/thekraken/grok/api/Converter.java
@@ -1,0 +1,186 @@
+package oi.thekraken.grok.api;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Converter {
+	
+	public static Map<String, IConverter<?>> _converters = new HashMap<String, IConverter<?>>();
+
+	static {
+		_converters.put("byte", new ByteConverter());
+		_converters.put("boolean", new BooleanConverter());
+		_converters.put("short", new ShortConverter());
+		_converters.put("int", new IntegerConverter());
+		_converters.put("long", new LongConverter());
+		_converters.put("float", new FloatConverter());
+		_converters.put("double", new DoubleConverter());
+		_converters.put("date", new DateConverter());
+		_converters.put("datetime", new DateConverter());
+		_converters.put("string", new StringConverter());
+
+	}
+	
+	private static IConverter getConverter(String key) throws Exception {
+		IConverter converter = _converters.get(key);
+		if (converter == null) {
+			throw new Exception("Invalid data type :" + key);
+		}
+		return converter;
+	}
+	
+	public static KeyValue convert(String key, Object value) {
+		String[] spec = key.split(";");
+		try {
+			if (spec.length == 1) {
+				return new KeyValue(spec[0], value);
+			} else if (spec.length == 2) {
+				return new KeyValue(spec[0], getConverter(spec[1]).convert(String.valueOf(value)));
+			} else if (spec.length == 3) {
+				return new KeyValue(spec[0], getConverter(spec[1]).convert(String.valueOf(value), spec[2]));
+			} else {
+				return new KeyValue(spec[0], value, "Unsupported spec :" + key);
+			}
+		} catch (Exception e) {
+			return new KeyValue(spec[0], value, e.toString());
+		}
+	}
+}
+
+
+//
+// KeyValue
+//
+
+class KeyValue {
+
+	private String key = null;
+	private Object value = null;
+	private String grokFailure = null;
+	
+	public KeyValue(String key, Object value) {
+		this.key = key;
+		this.value = value;
+	}
+	
+	public KeyValue(String key, Object value, String grokFailure) {
+		this.key = key;
+		this.value = value;
+		this.grokFailure = grokFailure;
+	}
+
+	public boolean hasGrokFailure() {
+		return grokFailure != null;
+	}
+
+	public String getGrokFailure() {
+		return this.grokFailure;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+
+	public void setValue(Object value) {
+		this.value = value;
+	}
+}
+
+
+//
+// Converters
+//
+abstract class IConverter<T> {
+	
+	public T convert(String value, String informat) throws Exception {
+		return null;
+	}
+	
+	public abstract T convert(String value) throws Exception;
+}
+
+class ByteConverter extends IConverter<Byte> {
+	@Override
+	public Byte convert(String value) throws Exception {
+		return Byte.parseByte(value);
+	}
+}
+
+class BooleanConverter extends IConverter<Boolean> {
+	@Override
+	public Boolean convert(String value) throws Exception {
+		return Boolean.parseBoolean(value);
+	}
+}
+
+class ShortConverter extends IConverter<Short> {
+	@Override
+	public Short convert(String value) throws Exception {
+		return Short.parseShort(value);
+	}
+}
+
+class IntegerConverter extends IConverter<Integer> {
+	@Override
+	public Integer convert(String value) throws Exception {
+		return Integer.parseInt(value);
+	}
+}
+
+class LongConverter extends IConverter<Long> {
+	@Override
+	public Long convert(String value) throws Exception {
+		return Long.parseLong(value);
+	}
+}
+
+class FloatConverter extends IConverter<Float> {
+	@Override
+	public Float convert(String value) throws Exception {
+		return Float.parseFloat(value);
+	}
+}
+
+class DoubleConverter extends IConverter<Double> {
+	@Override
+	public Double convert(String value) throws Exception {
+		return Double.parseDouble(value);
+	}
+}
+
+class StringConverter extends IConverter<String> {
+	@Override
+	public String convert(String value) throws Exception {
+		return value;
+	}
+}
+
+class DateConverter extends IConverter<Date> {
+	@Override
+	public Date convert(String value) throws Exception {
+		return DateFormat.getInstance().parse(value);
+	}
+	
+	@Override
+	public Date convert(String value, String informat) throws Exception {
+		SimpleDateFormat formatter =  new SimpleDateFormat(informat);
+		return formatter.parse(value);
+	}
+	
+}
+
+
+
+
+

--- a/src/main/java/oi/thekraken/grok/api/GrokUtils.java
+++ b/src/main/java/oi/thekraken/grok/api/GrokUtils.java
@@ -17,7 +17,7 @@ public class GrokUtils {
       "%\\{" +
       "(?<name>" +
         "(?<pattern>[A-z0-9]+)" +
-          "(?::(?<subname>[A-z0-9_:]+))?" +
+          "(?::(?<subname>[A-z0-9_:;\\/\\s\\.]+))?" +
           ")" +
           "(?:=(?<definition>" +
             "(?:" +

--- a/src/main/java/oi/thekraken/grok/api/Match.java
+++ b/src/main/java/oi/thekraken/grok/api/Match.java
@@ -160,14 +160,26 @@ public class Match {
       }
       if (pairs.getValue() != null) {
         value = pairs.getValue().toString();
-        if (this.isInteger(value.toString())) {
-          value = Integer.parseInt(value.toString());
+        
+        KeyValue keyValue = Converter.convert(key, value);
+        
+        //get validated key
+        key = keyValue.getKey();
+        
+        //resolve value
+        if (keyValue.getValue() instanceof String) {
+        	 value = cleanString((String)keyValue.getValue());
         } else {
-          value = cleanString(pairs.getValue().toString());
+        	value = keyValue.getValue();
+        }
+        
+        //set if grok failure
+        if (keyValue.hasGrokFailure()) {
+        	capture.put(key + "_grokfailure", keyValue.getGrokFailure());
         }
       }
 
-      capture.put(key, (Object) value);
+      capture.put(key, value);
       it.remove(); // avoids a ConcurrentModificationException
     }
   }
@@ -284,4 +296,6 @@ public class Match {
     }
     return true;
   }
+  
 }
+

--- a/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
+++ b/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
@@ -1,0 +1,54 @@
+package io.thekraken.grok.api;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+
+import oi.thekraken.grok.api.Grok;
+import oi.thekraken.grok.api.Match;
+import oi.thekraken.grok.api.exception.GrokException;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ApacheDataTypeTest {
+
+  public final static String LOG_FILE = "src/test/resources/access_log";
+  public final static String LOG_DIR_NASA = "src/test/resources/nasa/";
+
+
+  @Test
+  public void test002_httpd_access() throws GrokException, IOException {
+    Grok g = Grok.create("patterns/patterns", "%{COMMONAPACHELOG_DATATYPED}");
+
+    BufferedReader br = new BufferedReader(new FileReader(LOG_FILE));
+    String line;
+    System.out.println("Starting test with httpd log");
+    while ((line = br.readLine()) != null) {
+      System.out.println(line);
+      Match gm = g.match(line);
+      gm.captures();
+      
+      assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
+
+      Map<String, Object> map = gm.toMap();
+      assertTrue(map.get("timestamp") == null || map.get("timestamp") instanceof Date);
+      assertTrue(map.get("response") == null || map.get("response") instanceof Integer);
+      assertTrue(map.get("ident") == null  || map.get("ident") instanceof Boolean);
+      assertTrue(map.get("httpversion") == null || map.get("httpversion") instanceof Float);
+      assertTrue(map.get("bytes") == null || map.get("bytes") instanceof Long);
+      assertTrue(map.get("verb") == null || map.get("verb") instanceof String);
+
+    }
+    br.close();
+  }
+
+ }


### PR DESCRIPTION
for ex: 
COMMONAPACHELOG_DATATYPED %{IPORHOST:clientip} %{USER:ident;boolean}
%{USER:auth} \[%{HTTPDATE:timestamp;date;dd/MMM/yyyy:HH:mm:ss Z}\]
"(?:%{WORD:verb;string} %{NOTSPACE:request}(?:
HTTP/%{NUMBER:httpversion;float})?|%{DATA:rawrequest})"
%{NUMBER:response;int} (?:%{NUMBER:bytes;long}|-)