### PR TITLE
Added pattern name check to Grok.compile()

### DIFF
--- a/src/main/java/oi/thekraken/grok/api/Grok.java
+++ b/src/main/java/oi/thekraken/grok/api/Grok.java
@@ -359,6 +359,9 @@ public class Grok {
             // Log the exeception
           }
         }
+        if(!grokPatternDefinition.containsKey(group.get("pattern"))){
+        	throw new GrokException("Pattern name " + group.get("pattern") + " unknown!");
+        }
         namedRegexCollection.put("name" + index,
             (group.get("subname") != null ? group.get("subname") : group.get("name")));
         namedRegex =


### PR DESCRIPTION
Grok.compile() silently ignored non-existent pattern names and simply placed "null". I have changed it to throw an exception if no pattern was found with given name. 