### PR TITLE
Set English locale for ApacheDataTypeTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
       <version>1.7.5</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
+++ b/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 
 import oi.thekraken.grok.api.Grok;
@@ -24,7 +25,10 @@ public class ApacheDataTypeTest {
   public final static String LOG_FILE = "src/test/resources/access_log";
   public final static String LOG_DIR_NASA = "src/test/resources/nasa/";
 
-
+  static {
+    Locale.setDefault(Locale.ENGLISH);
+  }
+  
   @Test
   public void test002_httpd_access() throws GrokException, IOException {
     Grok g = Grok.create("patterns/patterns", "%{COMMONAPACHELOG_DATATYPED}");


### PR DESCRIPTION
The `DateConverter` class is dependent on the current default locale which makes `ApacheDataTypeTest` fail for several languages/locales other than English.

This PR sets `Locale.ENGLISH` as default locale for this test and fixes #27.