### PR TITLE
Making Grok Serializable

### DIFF
--- a/src/main/java/oi/thekraken/grok/api/Grok.java
+++ b/src/main/java/oi/thekraken/grok/api/Grok.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +55,7 @@ import com.google.code.regexp.Pattern;
  * @since 0.0.1
  * @author anthonycorbacho
  */
-public class Grok {
+public class Grok implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(Grok.class);
   /**


### PR DESCRIPTION
Anthony, this project is pretty neat!  thank you for sharing this. I am testing this grok to parse data in spark, but hit exception since Grok is not serializable.  I think this will be one common usecase, does it make sense to make Grok serializable? 
-------
Exception in thread "main" org.apache.spark.SparkException: Task not serializable
..
Caused by: java.io.NotSerializableException: oi.thekraken.grok.api.Grok
Serialization stack:
	- object not serializable (class: oi.thekraken.grok.api.Grok, value: oi.thekraken.grok.api.Grok@7da8ca25)
------

