### PR TITLE
Issue #36: Data type conversion and compatiblity with Logstash's grok

### DIFF
--- a/src/main/java/oi/thekraken/grok/api/Converter.java
+++ b/src/main/java/oi/thekraken/grok/api/Converter.java
@@ -41,7 +41,7 @@ public class Converter {
   }
 
   public static KeyValue convert(String key, Object value) {
-    String[] spec = key.split(";");
+    String[] spec = key.split(";|:",3);
     try {
       if (spec.length == 1) {
         return new KeyValue(spec[0], value);

--- a/src/test/java/io/thekraken/grok/api/CaptureTest.java
+++ b/src/test/java/io/thekraken/grok/api/CaptureTest.java
@@ -82,14 +82,14 @@ public class CaptureTest {
     @Test
     public void test005_captureSubName() throws GrokException {
         String name = "foo";
-        String subname = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_abc:def";
+        String subname = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_abcdef";
         grok.addPattern(name, "\\w+");
         grok.compile("%{" + name + ":" + subname + "}");
         Match m = grok.match("Hello");
         m.captures();
         assertEquals(1, m.toMap().size());
         assertEquals("Hello", m.toMap().get(subname).toString());
-        assertEquals("{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_abc:def=Hello}", m.toMap().toString());
+        assertEquals("{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_abcdef=Hello}", m.toMap().toString());
     }
 
 }


### PR DESCRIPTION
Modified converter per issue to allow for ":" as a type delimiter.
Altered ApacheDataTypeTest to correctly detect errors, and added
a test for ":" delimeter, as the original file used ";".

An unintended side effect is that capture names can no longer have
the colon (:) character in the name. Updated CaptureTest.