### PR TITLE
Gson are now static final fields to improve performance

### DIFF
--- a/src/main/java/oi/thekraken/grok/api/Match.java
+++ b/src/main/java/oi/thekraken/grok/api/Match.java
@@ -33,6 +33,10 @@ import com.google.gson.GsonBuilder;
  */
 public class Match {
 
+  private static final Gson PRETTY_GSON =
+          new GsonBuilder().setPrettyPrinting().create();
+  private static final Gson GSON = new GsonBuilder().create();
+
   private String subject; // texte
   private Map<String, Object> capture;
   private Garbage garbage;
@@ -227,9 +231,9 @@ public class Match {
     this.cleanMap();
     Gson gs;
     if (pretty) {
-      gs = new GsonBuilder().setPrettyPrinting().create();
+      gs = PRETTY_GSON;
     } else {
-      gs = new Gson();
+      gs = GSON;
     }
     return gs.toJson(/* cleanMap( */capture/* ) */);
   }


### PR DESCRIPTION
Instead of creating a new Gson instance for each invocation, they are not static final fields to avoid the overhead of creating them each time. The Gson instance is threadsafe so there should be no issues (anymore).

I did a naive performance test with the old and my suggested approach. I also did a test to compare with jackson but could not find any notable difference.

Time in milliseconds

    Old: 4032 2547 2034 2146 2007 2025 1951 2041 2028 2021
    New: 2350 1332 1247 1232 1263 1258 1259 1224 1295 1299

The difference is quite big, "almost" a second per 150.000 invocations. 

```java
    @Test
    public void naivePerfTest() throws GrokException {
        for( int i = 0; i < 10; i++) {
            runWithTimer();
        }
    }
    public void runWithTimer() throws GrokException {
        Grok grok = Grok.create("patterns/patterns", "%{URI}");
        long start = System.currentTimeMillis();
        for (int a = 0; a < 150000; a++) {
                Match m = grok.match("telnet://helloworld");
                m.captures();
                m.toJson();
        }
        System.out.println(System.currentTimeMillis() - start);
    }
```