### PR TITLE
Fix match against null

### DIFF
--- a/src/main/java/oi/thekraken/grok/api/Pile.java
+++ b/src/main/java/oi/thekraken/grok/api/Pile.java
@@ -124,7 +124,7 @@ public class Pile {
   public Match match(String line) {
     for (Grok grok : _groks) {
       Match gm = grok.match(line);
-      if (gm != null)
+      if (!gm.isNull())
         return gm;
     }
 


### PR DESCRIPTION
I know that `Pile` is deprecated, but this change makes it work because [Grok#match always returns a `Match` object](https://github.com/thekrakken/java-grok/blob/master/src/main/java/oi/thekraken/grok/api/Grok.java#L318), thus the var `gm` can not be `null` and nullity must be ckecked with `Match#isNull`.