### PR TITLE
Enable pre 0.1.3 behavior of parsing captured values to integers

### DIFF
--- a/src/main/java/io/thekraken/grok/api/Converter.java
+++ b/src/main/java/io/thekraken/grok/api/Converter.java
@@ -41,9 +41,18 @@ public class Converter {
   }
 
   public static KeyValue convert(String key, Object value) {
+    return convert(key,value,false);
+  }
+
+  public static KeyValue convert(String key, Object value, boolean convertIntegerStrings){
     String[] spec = key.split(";|:",3);
     try {
       if (spec.length == 1) {
+        if(convertIntegerStrings){
+          if (isInteger(value.toString())) {
+            value = Integer.parseInt(value.toString());
+          }
+        }
         return new KeyValue(spec[0], value);
       } else if (spec.length == 2) {
         return new KeyValue(spec[0], getConverter(spec[1]).convert(String.valueOf(value)));
@@ -55,6 +64,20 @@ public class Converter {
     } catch (Exception e) {
       return new KeyValue(spec[0], value, e.toString());
     }
+  }
+  /**
+   * Util fct.
+   *
+   * @param s
+   * @return boolean
+   */
+  private static boolean isInteger(String s) {
+    try {
+      Integer.parseInt(s);
+    } catch (NumberFormatException e) {
+      return false;
+    }
+    return true;
   }
 }
 

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -144,6 +144,16 @@ public class Match {
    */
   @SuppressWarnings("unchecked")
   public void captures() {
+      captures(false);
+  }
+
+  /**
+   *  Match to the <tt>subject</tt> the <tt>regex</tt> and save the matched element into a map.
+   *  if Integers can be parsed from values without conversion modifiers, they will be
+   * @param convertIntegerStrings
+   */
+  @SuppressWarnings("unchecked")
+  public void captures(boolean convertIntegerStrings){
     if (match == null) {
       return;
     }
@@ -168,7 +178,7 @@ public class Match {
       if (pairs.getValue() != null) {
         value = pairs.getValue().toString();
 
-        KeyValue keyValue = Converter.convert(key, value);
+        KeyValue keyValue = Converter.convert(key, value, convertIntegerStrings);
 
         // get validated key
         key = keyValue.getKey();

--- a/src/test/java/io/thekraken/grok/api/CaptureTest.java
+++ b/src/test/java/io/thekraken/grok/api/CaptureTest.java
@@ -8,7 +8,9 @@ import org.junit.runners.MethodSorters;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CaptureTest {

--- a/src/test/java/io/thekraken/grok/api/CaptureTest.java
+++ b/src/test/java/io/thekraken/grok/api/CaptureTest.java
@@ -6,11 +6,9 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
+
+import static org.junit.Assert.*;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CaptureTest {
@@ -116,4 +114,16 @@ public class CaptureTest {
     	assertEquals(((List<Object>) (m.toMap().get("id"))).get(1),"456");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test008_captureIntegerOrString() throws GrokException {
+        grok.compile("%{INT:id}");
+        Match m = grok.match("123");
+        m.captures();
+        assertEquals(m.toMap().size(),1);
+        assertTrue(m.toMap().get("id").getClass() == String.class);
+        m.captures(true);
+        assertEquals(m.toMap().size(),1);
+        assertTrue(m.toMap().get("id").getClass() == Integer.class);
+    }
 }


### PR DESCRIPTION
Users or systems with significant grok pattern sets are regressed by the behavior introduced in 0.1.3 with regards to the parsing of integers to integer types.  Rules that would once produce Integer will now produce String captures from the map.

This PR allows a flag to be passed to a new Match.capture function and subsequently to the Converter.convert such that the prior behavior can be maintained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thekrakken/java-grok/60)
<!-- Reviewable:end -->
