### PR TITLE
Match#capture: flatten multiple values to the same key

### DIFF
--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -242,22 +242,6 @@ public class Match {
       
       it.remove(); // avoids a ConcurrentModificationException
     }
-
-    if (flattened) {
-      flattenCaptures();
-    }
-  }
-
-  @SuppressWarnings("SuspiciousMethodCalls")
-  private void flattenCaptures() {
-    for (Entry<String, Object> entry : capture.entrySet()) {
-      if (entry.getValue() instanceof List) {
-        List<?> list = (List<?>) entry.getValue();
-
-        list.removeAll(Collections.singleton(null));
-
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
Sometimes there are multiple ways a key can be captured. With 0.1.5 I get a list of the value and null. The new capturesFlattened cleans up multiple values as long as there is only one non-null value.

@anthonycorbacho  I don't know if you like the additional capture Method. Or if you would prefer an option for the grok/matcher object itself? And what do you think about the exception, I'd like to warn the user about an ambiguity. 