### PR TITLE
Grok Compiler: wrap grok patterns in (?:...) in namedOnly mode

### DIFF
--- a/src/main/java/io/thekraken/grok/api/Grok.java
+++ b/src/main/java/io/thekraken/grok/api/Grok.java
@@ -390,7 +390,7 @@ public class Grok implements Serializable {
         for (int i = 0; i < count; i++) {
           String replacement = String.format("(?<name%d>%s)", index, grokPatternDefinition.get(group.get("pattern")));
           if (namedOnly && group.get("subname") == null) {
-            replacement = grokPatternDefinition.get(group.get("pattern"));
+            replacement = String.format("(?:%s)", grokPatternDefinition.get(group.get("pattern")));
           }
           namedRegexCollection.put("name" + index,
               (group.get("subname") != null ? group.get("subname") : group.get("name")));


### PR DESCRIPTION
This ensures that the namedOnly behaves similar like the normal mode.

i.E.
```
WORD foo|bar
TEXT %{WORD}+
```
  => should render to ```(?:foo|bar)+```and NOT ```foo|bar+```

Fixes https://github.com/thekrakken/java-grok/issues/61
