### PR TITLE
Grok/Match: provide option to completely disable automatic conversion

### DIFF
--- a/src/main/java/io/thekraken/grok/api/Grok.java
+++ b/src/main/java/io/thekraken/grok/api/Grok.java
@@ -86,6 +86,12 @@ public class Grok implements Serializable {
   /** only use in grok discovery. */
   private String savedPattern;
 
+
+  /**
+   * automatic conversion of values
+   */
+  private boolean automaticConversionEnabled = true;
+
   /**
    * Create Empty {@code Grok}.
    */
@@ -260,7 +266,17 @@ public class Grok implements Serializable {
     } catch (GrokException e) {
       throw new GrokException(e.getMessage());
     }
+  }
 
+  /**
+   * Disable automatic conversion of values
+   */
+  public void disableAutomaticConversion() {
+    this.automaticConversionEnabled = false;
+  }
+
+  public boolean isAutomaticConversionEnabled() {
+    return automaticConversionEnabled;
   }
 
   /**

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -148,6 +148,8 @@ public class Match {
       return;
     }
     capture.clear();
+    boolean automaticConversionEnabled = grok.isAutomaticConversionEnabled();
+
 
     // _capture.put("LINE", this.line);
     // _capture.put("LENGTH", this.line.length() +"");
@@ -168,21 +170,24 @@ public class Match {
       if (pairs.getValue() != null) {
         value = pairs.getValue().toString();
 
-        KeyValue keyValue = Converter.convert(key, value);
 
-        // get validated key
-        key = keyValue.getKey();
+        if (automaticConversionEnabled) {
+          KeyValue keyValue = Converter.convert(key, value);
 
-        // resolve value
-        if (keyValue.getValue() instanceof String) {
-          value = cleanString((String) keyValue.getValue());
-        } else {
-          value = keyValue.getValue();
-        }
+          // get validated key
+          key = keyValue.getKey();
 
-        // set if grok failure
-        if (keyValue.hasGrokFailure()) {
-          capture.put(key + "_grokfailure", keyValue.getGrokFailure());
+          // resolve value
+          if (keyValue.getValue() instanceof String) {
+            value = cleanString((String) keyValue.getValue());
+          } else {
+            value = keyValue.getValue();
+          }
+
+          // set if grok failure
+          if (keyValue.hasGrokFailure()) {
+            capture.put(key + "_grokfailure", keyValue.getGrokFailure());
+          }
         }
       }
 

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -522,4 +522,17 @@ public class GrokTest {
         assertEquals(i, 4);
     }
 
+    /* see: https://github.com/thekrakken/java-grok/issues/64 */
+    @Test
+    public void testDisablingAutomaticConversion() throws GrokException {
+        String input = "client id: \"foo\" \"bar\"";
+        String pattern = "(?<message>client id): (?<clientid>.*)";
+
+        Grok grok = new Grok();
+        grok.disableAutomaticConversion();
+        grok.compile(pattern, false);
+        Match gm = grok.match(input);
+        gm.captures();
+        assertEquals("\"foo\" \"bar\"", gm.toMap().get("clientid"));
+    }
 }


### PR DESCRIPTION
Provide option on Grok object to disable automatic key/value conversion. 

@anthonycorbacho  as with the other PRs I'm open to any changes how these options/settings should be organized.

Fixes #64