### PR TITLE
Match.capture nows throws a GrokException

### DIFF
--- a/src/main/java/io/krakens/grok/api/Grok.java
+++ b/src/main/java/io/krakens/grok/api/Grok.java
@@ -9,6 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import io.krakens.grok.api.Converter.IConverter;
+import io.krakens.grok.api.exception.GrokException;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/io/krakens/grok/api/Match.java
+++ b/src/main/java/io/krakens/grok/api/Match.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 
 import io.krakens.grok.api.Converter.IConverter;
+import io.krakens.grok.api.exception.GrokException;
 
 /**
  * {@code Match} is a representation in {@code Grok} world of your log.
@@ -84,12 +85,20 @@ public class Match {
    *
    * See also {@link #capture} which returns multiple values of the same key as list.
    *
+   * @return the matched elements
+   * @throws GrokException if a keys has multiple non-null values.
    */
-  public Map<String, Object> captureFlattened() {
+  public Map<String, Object> captureFlattened() throws GrokException {
     return capture(true);
   }
 
-  private Map<String, Object> capture(boolean flattened ) {
+  /**
+   * Private implementation of captureFlattened and capture.
+   * @param will it flatten values.
+   * @return the matched elements.
+   * @throws GrokException if a keys has multiple non-null values, but only if flattened is set to true.
+   */
+  private Map<String, Object> capture(boolean flattened ) throws GrokException {
     if (match == null) {
       return Collections.emptyMap();
     }
@@ -143,7 +152,7 @@ public class Match {
             capture.put(key, value);
           }
           if (currentValue != null && value != null) {
-            throw new RuntimeException(
+            throw new GrokException(
                 format(
                     "key '%s' has multiple non-null values, this is not allowed in flattened mode, values:'%s', '%s'",
                     key,


### PR DESCRIPTION
Match.capture nows throws a GrokException instead of the too generic RuntimeException.
And described in javadoc.

Fixing #89 