### PR TITLE
Removed warnings, as returned by Eclipse.

### DIFF
--- a/src/main/java/io/krakens/grok/api/Converter.java
+++ b/src/main/java/io/krakens/grok/api/Converter.java
@@ -35,10 +35,10 @@ public class Converter {
     DATETIME(new DateConverter(), "date"),
     STRING(v -> v, "text");
 
-    public final IConverter<?> converter;
+    public final IConverter<? extends Object> converter;
     public final List<String> aliases;
 
-    Type(IConverter<?> converter, String... aliases) {
+    Type(IConverter<? extends Object> converter, String... aliases) {
       this.converter = converter;
       this.aliases = Arrays.asList(aliases);
     }
@@ -64,12 +64,13 @@ public class Converter {
     return type;
   }
 
-  public static Map<String, IConverter> getConverters(Collection<String> groupNames, Object... params) {
+  public static Map<String, IConverter<? extends Object>>
+      getConverters(Collection<String> groupNames, Object... params) {
     return groupNames.stream()
         .filter(Converter::containsDelimiter)
         .collect(Collectors.toMap(Function.identity(), key -> {
           String[] list = splitGrokPattern(key);
-          IConverter converter = getType(list[1]).converter;
+          IConverter<? extends Object> converter = getType(list[1]).converter;
           if (list.length == 3) {
             converter = converter.newConverter(list[2], params);
           }

--- a/src/main/java/io/krakens/grok/api/Grok.java
+++ b/src/main/java/io/krakens/grok/api/Grok.java
@@ -49,7 +49,7 @@ public class Grok {
 
   public final Map<String, Converter.Type> groupTypes;
 
-  public final Map<String, IConverter> converters;
+  public final Map<String, IConverter<? extends Object>> converters;
 
   /**
    * {@code Grok} discovery.

--- a/src/main/java/io/krakens/grok/api/Match.java
+++ b/src/main/java/io/krakens/grok/api/Match.java
@@ -117,7 +117,7 @@ public class Match {
 
       Object value = valueString;
       if (valueString != null) {
-        IConverter converter = grok.converters.get(key);
+        IConverter<?> converter = grok.converters.get(key);
 
         if (converter != null) {
           key = Converter.extractKey(key);
@@ -152,7 +152,9 @@ public class Match {
           }
         } else {
           if (currentValue instanceof List) {
-            ((List<Object>) currentValue).add(value);
+            @SuppressWarnings("unchecked")
+            List<Object> cvl = (List<Object>) currentValue;
+            cvl.add(value);
           } else {
             List<Object> list = new ArrayList<Object>();
             list.add(currentValue);

--- a/src/test/java/io/krakens/grok/api/CaptureTest.java
+++ b/src/test/java/io/krakens/grok/api/CaptureTest.java
@@ -123,7 +123,6 @@ public class CaptureTest {
     assertEquals(((List<Object>) (map.get("id"))).get(1), "456");
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void test008_flattenDuplicateKeys() throws GrokException {
     Grok grok = compiler.compile("(?:foo %{INT:id} bar|bar %{INT:id} foo)");

--- a/src/test/java/io/krakens/grok/api/GrokTest.java
+++ b/src/test/java/io/krakens/grok/api/GrokTest.java
@@ -312,14 +312,16 @@ public class GrokTest {
   public void test013_IpSet() throws Throwable {
     Grok grok = compiler.compile("%{IP}");
 
-    BufferedReader br = new BufferedReader(new FileReader(Resources.getResource(ResourceManager.IP).getFile()));
-    String line;
-    System.out.println("Starting test with ip");
-    while ((line = br.readLine()) != null) {
-      Match gm = grok.match(line);
-      final Map<String, Object> map = gm.capture();
-      Assertions.assertThat(map).doesNotContainKey("Error");
-      assertEquals(map.get("IP"), line);
+    try (FileReader fr = new FileReader(Resources.getResource(ResourceManager.IP).getFile());
+        BufferedReader br = new BufferedReader(fr)) {
+      String line;
+      System.out.println("Starting test with ip");
+      while ((line = br.readLine()) != null) {
+        Match gm = grok.match(line);
+        final Map<String, Object> map = gm.capture();
+        Assertions.assertThat(map).doesNotContainKey("Error");
+        assertEquals(map.get("IP"), line);
+      }
     }
   }
 


### PR DESCRIPTION
Removed warnings, as returned by Eclipse:
- about IConverter templates;
- resources leak in GrokTest;
- a useless SupressWarnings in CaptureTest.