### PR TITLE
Preserve the order of log format in capture

### DIFF
--- a/src/main/java/io/krakens/grok/api/Match.java
+++ b/src/main/java/io/krakens/grok/api/Match.java
@@ -5,7 +5,7 @@ import static java.lang.String.format;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -61,7 +61,7 @@ public class Match {
   public void setKeepEmptyCaptures(boolean ignore) {
     // clear any cached captures
     if ( capture.size() > 0) {
-      capture = new HashMap<>();
+      capture = new LinkedHashMap<>();
     }
     this.keepEmptyCaptures = ignore;
   }
@@ -122,7 +122,7 @@ public class Match {
       return capture;
     }
 
-    capture = new HashMap<>();
+    capture = new LinkedHashMap<>();
 
     // _capture.put("LINE", this.line);
     // _capture.put("LENGTH", this.line.length() +"");

--- a/src/test/java/io/krakens/grok/api/CaptureTest.java
+++ b/src/test/java/io/krakens/grok/api/CaptureTest.java
@@ -54,7 +54,7 @@ public class CaptureTest {
     assertEquals(2, map.size());
     assertEquals("Hello", map.get("foo"));
     assertEquals("World", map.get("bar"));
-    assertEquals("{bar=World, foo=Hello}", map.toString());
+    assertEquals("{foo=Hello, bar=World}", map.toString());
   }
 
   @Test
@@ -69,7 +69,7 @@ public class CaptureTest {
     assertEquals(2, map.size());
     assertEquals("Hello World", map.get("foo"));
     assertEquals("World", map.get("bar"));
-    assertEquals("{bar=World, foo=Hello World}", map.toString());
+    assertEquals("{foo=Hello World, bar=World}", map.toString());
   }
 
   @Test


### PR DESCRIPTION
Dear java-grok maintainers,

Please accept this PR.

**Analysis**
Currently, capture is returning the unordered Map.

**Resolution**
Return the map with the same order as log format(pattern).

**Test**
Tested with different types of logs.