### PR TITLE
Update classes as serializable to work with bigdata beam pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
+dist: trusty

--- a/src/main/java/io/krakens/grok/api/Grok.java
+++ b/src/main/java/io/krakens/grok/api/Grok.java
@@ -1,5 +1,6 @@
 package io.krakens.grok.api;
 
+import java.io.Serializable;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @since 0.0.1
  */
-public class Grok {
+public class Grok implements Serializable {
   /**
    * Named regex of the originalGrokPattern.
    */

--- a/src/main/java/io/krakens/grok/api/GrokCompiler.java
+++ b/src/main/java/io/krakens/grok/api/GrokCompiler.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
@@ -22,7 +23,7 @@ import io.krakens.grok.api.exception.GrokException;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class GrokCompiler {
+public class GrokCompiler implements Serializable {
 
   // We don't want \n and commented line
   private static final Pattern patternLinePattern = Pattern.compile("^([A-z0-9_]+)\\s+(.*)$");


### PR DESCRIPTION
Made Grok and GrokCompiler classes serializable to work in Apache Beam pipeline programming